### PR TITLE
Upgrade CI to use Go 1.15.2

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,19 +5,19 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.14
+      - name: Set up Go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14.2
+          go-version: 1.15.2
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
 
       - name: Setup Lint
-        run: curl -LO https://github.com/golangci/golangci-lint/releases/download/v1.24.0/golangci-lint-1.24.0-linux-amd64.tar.gz && tar -xf golangci-lint-1.24.0-linux-amd64.tar.gz
+        run: curl -LO https://github.com/golangci/golangci-lint/releases/download/v1.31.0/golangci-lint-1.31.0-linux-amd64.tar.gz && tar -xf golangci-lint-1.31.0-linux-amd64.tar.gz
 
       - name: Lint
-        run: golangci-lint-1.24.0-linux-amd64/golangci-lint run
+        run: golangci-lint-1.31.0-linux-amd64/golangci-lint run
 
       - name: Setup Build
         run: go get github.com/mitchellh/gox && mkdir -p bin && go mod download

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,4 +23,4 @@ jobs:
         run: go get github.com/mitchellh/gox && mkdir -p bin && go mod download
 
       - name: Build
-        run: ~/go/bin/gox -osarch="darwin/386 darwin/amd64 linux/386 linux/amd64 linux/arm windows/amd64" -ldflags="-extldflags '-static' -X github.com/signmykeyio/signmykey/cmd.versionString=${GITHUB_RUN_NUMBER}" -output="bin/signmykey_{{.OS}}_{{.Arch}}"
+        run: ~/go/bin/gox -osarch="darwin/amd64 linux/386 linux/amd64 linux/arm windows/amd64" -ldflags="-extldflags '-static' -X github.com/signmykeyio/signmykey/cmd.versionString=${GITHUB_RUN_NUMBER}" -output="bin/signmykey_{{.OS}}_{{.Arch}}"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -8,10 +8,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.14
+      - name: Set up Go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14.2
+          go-version: 1.15.2
 
       - name: Get the version
         id: get_version
@@ -21,10 +21,10 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Setup Lint
-        run: curl -LO https://github.com/golangci/golangci-lint/releases/download/v1.24.0/golangci-lint-1.24.0-linux-amd64.tar.gz && tar -xf golangci-lint-1.24.0-linux-amd64.tar.gz
+        run: curl -LO https://github.com/golangci/golangci-lint/releases/download/v1.31.0/golangci-lint-1.31.0-linux-amd64.tar.gz && tar -xf golangci-lint-1.31.0-linux-amd64.tar.gz
 
       - name: Lint
-        run: golangci-lint-1.24.0-linux-amd64/golangci-lint run
+        run: golangci-lint-1.31.0-linux-amd64/golangci-lint run
 
       - name: Setup Build
         run: go get github.com/mitchellh/gox && mkdir -p bin && go mod download

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -30,7 +30,7 @@ jobs:
         run: go get github.com/mitchellh/gox && mkdir -p bin && go mod download
 
       - name: Build
-        run: ~/go/bin/gox -osarch="darwin/386 darwin/amd64 linux/386 linux/amd64 linux/arm windows/amd64" -ldflags="-extldflags '-static' -X github.com/signmykeyio/signmykey/cmd.versionString=${{ steps.get_version.outputs.VERSION }}" -output="bin/signmykey_{{.OS}}_{{.Arch}}"
+        run: ~/go/bin/gox -osarch="darwin/amd64 linux/386 linux/amd64 linux/arm windows/amd64" -ldflags="-extldflags '-static' -X github.com/signmykeyio/signmykey/cmd.versionString=${{ steps.get_version.outputs.VERSION }}" -output="bin/signmykey_{{.OS}}_{{.Arch}}"
 
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v1-release

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,7 @@ build: ## Build the binary file
 	go get github.com/mitchellh/gox
 	mkdir -p bin
 	go mod download
-	gox -osarch="darwin/386 darwin/amd64 linux/386 linux/amd64 linux/arm windows/amd64" -ldflags="-extldflags '-static' -X github.com/signmykeyio/signmykey/cmd.versionString=${SHORT_VERSION}" -output="bin/signmykey_{{.OS}}_{{.Arch}}"
-	zip -j bin/signmykey_darwin_386.zip bin/signmykey_darwin_386
+	gox -osarch="darwin/amd64 linux/386 linux/amd64 linux/arm windows/amd64" -ldflags="-extldflags '-static' -X github.com/signmykeyio/signmykey/cmd.versionString=${SHORT_VERSION}" -output="bin/signmykey_{{.OS}}_{{.Arch}}"
 	zip -j bin/signmykey_darwin_amd64.zip bin/signmykey_darwin_amd64
 	zip -j bin/signmykey_linux_386.zip bin/signmykey_linux_386
 	zip -j bin/signmykey_linux_amd64.zip bin/signmykey_linux_amd64


### PR DESCRIPTION
* Upgrade Go to 1.15.2
* Upgrade golangci-lint to 1.31.0
* Remove deprecated arch "darwin/386" 