### PR TITLE
ldap principal provider: add option to add user to principals list

### DIFF
--- a/builtin/principals/ldap/Principals.go
+++ b/builtin/principals/ldap/Principals.go
@@ -30,6 +30,7 @@ type Principals struct {
 	TLSVerify       bool
 	Prefix          string
 	TransformCase   string
+	AddUser         bool
 }
 
 type ldapPrincipals struct {
@@ -81,6 +82,7 @@ func (p *Principals) Init(config *viper.Viper) error {
 	p.GroupSearchStr = config.GetString("ldapGroupSearch")
 	p.Prefix = config.GetString("ldapGroupPrefix")
 	p.TransformCase = tc
+	p.AddUser = config.GetBool("addUser")
 
 	return nil
 }
@@ -144,6 +146,10 @@ func (p Principals) Get(ctx context.Context, payload []byte) (context.Context, [
 	principals = getCN(principals)
 	principals = filterByPrefix(p.Prefix, principals)
 	principals = common.TransformCase(p.TransformCase, principals)
+
+	if p.AddUser {
+		principals = append(principals, ldapPrinc.User)
+	}
 
 	return ctx, principals, nil
 }

--- a/docs/content/backends/principals/index.md
+++ b/docs/content/backends/principals/index.md
@@ -51,6 +51,7 @@ principalsOpts:
   * **ldapGroupSearch** - LDAP search string to find groups
   * **ldapGroupPrefix** - Filter LDAP groups by prefix
   * **transformCase** - Change case of returned principals (default: none) (must be "none", "lower" or "upper")
+  * **addUser** - Add the username you used to login to the principals list
 
 ## OIDC ROPC
 


### PR DESCRIPTION
Hello. I missed some feature in signmykey, so I made this small patch. I think it can be useful for anybody else.

We have some servers integrated with ldap (Active Directory) via sssd. So it will be easier to integrate signmykey with such configuration if principals list contains domain username. In this case, we don't have to add AuthorizedPrincipalsFile to sshd_config.