### PR TITLE
Add ability to use multiple principals providers

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -26,7 +26,7 @@ type Config struct {
 	Logger *logrus.Logger
 
 	Auth   authenticator.Authenticator
-	Princs principals.Principals
+	Princs []principals.Principals
 	Signer signer.Signer
 }
 

--- a/api/signHandler.go
+++ b/api/signHandler.go
@@ -59,9 +59,7 @@ func signHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		for _, v := range princs {
-			principals = append(principals, v)
-		}
+		principals = append(principals, princs...)
 	}
 
 	if len(principals) == 0 {

--- a/api/signHandler_test.go
+++ b/api/signHandler_test.go
@@ -220,7 +220,7 @@ func TestSignHandlerNoPrincipalsFound(t *testing.T) {
 		{
 			"POST", "/v1/sign", 401,
 			[]byte(`{"user":"emptyprincsuser","password":"testpassword","public_key":"goodkey"}`),
-			JSONResponse{"error": "no principals found"},
+			JSONResponse{"error": "error getting list of principals"},
 			"application/json",
 		},
 	}

--- a/builtin/principals/Principals.go
+++ b/builtin/principals/Principals.go
@@ -12,12 +12,13 @@ type Principals interface {
 	Get(ctx context.Context, payload []byte) (context.Context, []string, error)
 }
 
-// principals errors
+// NotFoundError it's principals provider error when no principals is found
 type NotFoundError struct {
 	provider string
 	msg      string
 }
 
+// NewNotFoundError creates new NotFoundError error with given privder name and message
 func NewNotFoundError(provider, msg string) *NotFoundError {
 	return &NotFoundError{provider: provider, msg: msg}
 }

--- a/builtin/principals/Principals.go
+++ b/builtin/principals/Principals.go
@@ -11,3 +11,17 @@ type Principals interface {
 	Init(config *viper.Viper) error
 	Get(ctx context.Context, payload []byte) (context.Context, []string, error)
 }
+
+// principals errors
+type NotFoundError struct {
+	provider string
+	msg      string
+}
+
+func NewNotFoundError(provider, msg string) *NotFoundError {
+	return &NotFoundError{provider: provider, msg: msg}
+}
+
+func (e *NotFoundError) Error() string {
+	return e.provider + ": " + e.msg
+}

--- a/builtin/principals/ldap/Principals.go
+++ b/builtin/principals/ldap/Principals.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	ldap "github.com/go-ldap/ldap/v3"
+	builtinPrincs "github.com/signmykeyio/signmykey/builtin/principals"
 	"github.com/signmykeyio/signmykey/builtin/principals/common"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -133,7 +134,7 @@ func (p Principals) Get(ctx context.Context, payload []byte) (context.Context, [
 	}
 
 	if len(gsr.Entries) == 0 {
-		return ctx, []string{}, errors.New("no group found for this user")
+		return ctx, []string{}, builtinPrincs.NewNotFoundError("ldap", "no group found for "+ldapPrinc.User)
 	}
 
 	var principals []string

--- a/builtin/principals/local/Principals.go
+++ b/builtin/principals/local/Principals.go
@@ -55,7 +55,7 @@ func (p Principals) Get(ctx context.Context, payload []byte) (context.Context, [
 	}
 
 	if len(principals) == 0 {
-		return ctx, principals, builtinPrincs.NewNotFoundError("ldap", "No more principals after trim for "+local.User)
+		return ctx, principals, builtinPrincs.NewNotFoundError("local", "No more principals after trim for "+local.User)
 	}
 
 	return ctx, principals, nil

--- a/builtin/principals/local/Principals.go
+++ b/builtin/principals/local/Principals.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	builtinPrincs "github.com/signmykeyio/signmykey/builtin/principals"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
@@ -54,7 +55,7 @@ func (p Principals) Get(ctx context.Context, payload []byte) (context.Context, [
 	}
 
 	if len(principals) == 0 {
-		return ctx, principals, fmt.Errorf("No more principals after trim for %s", local.User)
+		return ctx, principals, builtinPrincs.NewNotFoundError("ldap", "No more principals after trim for "+local.User)
 	}
 
 	return ctx, principals, nil

--- a/builtin/principals/user/Principals.go
+++ b/builtin/principals/user/Principals.go
@@ -1,4 +1,4 @@
-package ldap
+package user
 
 import (
 	"context"

--- a/builtin/principals/user/Principals.go
+++ b/builtin/principals/user/Principals.go
@@ -1,0 +1,37 @@
+package ldap
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+// Principals struct represents user options.
+type Principals struct{}
+
+type userPrincipals struct {
+	User string `json:"user" binding:"required"`
+}
+
+// Init method is used to ingest config of Principals
+func (p *Principals) Init(config *viper.Viper) error {
+	return nil
+}
+
+// Get method is used to get the list of principals associated to a specific user.
+func (p Principals) Get(ctx context.Context, payload []byte) (context.Context, []string, error) {
+
+	var userPrinc userPrincipals
+	err := json.Unmarshal(payload, &userPrinc)
+	if err != nil {
+		log.Errorf("json unmarshaling failed: %s", err)
+		return ctx, []string{}, fmt.Errorf("JSON unmarshaling failed: %w", err)
+	}
+
+	principals := []string{userPrinc.User}
+
+	return ctx, principals, nil
+}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -14,6 +14,7 @@ import (
 	ldapPrinc "github.com/signmykeyio/signmykey/builtin/principals/ldap"
 	localPrinc "github.com/signmykeyio/signmykey/builtin/principals/local"
 	oidcropcPrinc "github.com/signmykeyio/signmykey/builtin/principals/oidcropc"
+	userPrinc "github.com/signmykeyio/signmykey/builtin/principals/user"
 	"github.com/signmykeyio/signmykey/builtin/signer"
 	localSign "github.com/signmykeyio/signmykey/builtin/signer/local"
 	vaultSign "github.com/signmykeyio/signmykey/builtin/signer/vault"
@@ -93,6 +94,7 @@ var serverCmd = &cobra.Command{
 			"local":    &localPrinc.Principals{},
 			"ldap":     &ldapPrinc.Principals{},
 			"oidcropc": &oidcropcPrinc.Principals{},
+			"user":     &userPrinc.Principals{},
 		}
 		princs, ok := princsType[princsTypeConfig]
 		if !ok {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -85,28 +85,58 @@ var serverCmd = &cobra.Command{
 		}
 
 		// Principals init
-		princsTypeConfig := viper.GetString("principalsType")
-		if princsTypeConfig == "" {
-			logger.WithField("ctx", "server").WithError(errors.New("principals type not defined in config")).Error("Setting Principals type")
-			return
-		}
 		princsType := map[string]principals.Principals{
 			"local":    &localPrinc.Principals{},
 			"ldap":     &ldapPrinc.Principals{},
 			"oidcropc": &oidcropcPrinc.Principals{},
 			"user":     &userPrinc.Principals{},
 		}
-		princs, ok := princsType[princsTypeConfig]
-		if !ok {
-			logger.WithField("ctx", "server").WithError(fmt.Errorf("unknown principals type %s", princsTypeConfig)).Error("Setting Principals type")
+		princsProviders := []principals.Principals{}
+
+		if viper.IsSet("principalsProviders") {
+			for princsTypeConfig := range viper.GetStringMap("principalsProviders") {
+				princsOptsSection := "principalsProviders." + princsTypeConfig
+
+				logger.WithField("ctx", "server").Infof("Configure %v principals provider", princsTypeConfig)
+				princs, ok := princsType[princsTypeConfig]
+				if !ok {
+					logger.WithField("ctx", "server").WithError(fmt.Errorf("unknown principals type %s", princsTypeConfig)).Error("Setting Principals type")
+					return
+				}
+				err = princs.Init(viper.Sub(princsOptsSection))
+				if err != nil {
+					logger.WithField("ctx", "server").WithError(err).Error("Setting Principals options")
+					return
+				}
+
+				princsProviders = append(princsProviders, princs)
+			}
+		} else {
+			princsTypeConfig := viper.GetString("principalsType")
+			if princsTypeConfig == "" {
+				logger.WithField("ctx", "server").WithError(errors.New("principals type not defined in config")).Error("Setting Principals type")
+				return
+			}
+
+			logger.WithField("ctx", "server").Infof("Configure %v principals provider", princsTypeConfig)
+			princs, ok := princsType[princsTypeConfig]
+			if !ok {
+				logger.WithField("ctx", "server").WithError(fmt.Errorf("unknown principals type %s", princsTypeConfig)).Error("Setting Principals type")
+				return
+			}
+			err = princs.Init(viper.Sub("principalsOpts"))
+			if err != nil {
+				logger.WithField("ctx", "server").WithError(err).Error("Setting Principals options")
+				return
+			}
+
+			princsProviders = append(princsProviders, princs)
+		}
+
+		if len(princsProviders) == 0 {
+			logger.WithField("ctx", "server").Error("principals providers list is not configured")
 			return
 		}
-		err = princs.Init(viper.Sub("principalsOpts"))
-		if err != nil {
-			logger.WithField("ctx", "server").WithError(err).Error("Setting Principals options")
-			return
-		}
-		princsProviders := []principals.Principals{princs}
 
 		// Signer init
 		signerTypeConfig := viper.GetString("signerType")

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -106,6 +106,7 @@ var serverCmd = &cobra.Command{
 			logger.WithField("ctx", "server").WithError(err).Error("Setting Principals options")
 			return
 		}
+		princsProviders := []principals.Principals{princs}
 
 		// Signer init
 		signerTypeConfig := viper.GetString("signerType")
@@ -140,7 +141,7 @@ var serverCmd = &cobra.Command{
 
 		config := api.Config{
 			Auth:   auth,
-			Princs: princs,
+			Princs: princsProviders,
 			Signer: signer,
 
 			Logger: logger,

--- a/cmd/server_dev.go
+++ b/cmd/server_dev.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/signmykeyio/signmykey/api"
 	localAuth "github.com/signmykeyio/signmykey/builtin/authenticator/local"
+	"github.com/signmykeyio/signmykey/builtin/principals"
 	localPrinc "github.com/signmykeyio/signmykey/builtin/principals/local"
 	localSign "github.com/signmykeyio/signmykey/builtin/signer/local"
 	"github.com/sirupsen/logrus"
@@ -87,7 +88,7 @@ users:
 
 		config := api.Config{
 			Auth:   auth,
-			Princs: princs,
+			Princs: []principals.Principals{princs},
 			Signer: signer,
 
 			Logger: logger,

--- a/docs/content/backends/principals/index.md
+++ b/docs/content/backends/principals/index.md
@@ -69,3 +69,13 @@ principalsOpts:
   * **oidcUserinfoEndpoint** - OpenID Connect userinfo Endpoint (required)
   * **oidcUserGroupsEntry** - OpenID Connect group entry name returned by userinfo endpoint (required)
   * **transformCase** - Change case of returned principals (default: none) (must be "none", "lower" or "upper")
+
+## User
+
+Just adds username that you used to login to the principals list
+
+### Example Usage
+
+```
+principalsType: user
+```

--- a/docs/content/backends/principals/index.md
+++ b/docs/content/backends/principals/index.md
@@ -79,3 +79,27 @@ Just adds username that you used to login to the principals list
 ```
 principalsType: user
 ```
+
+## Multiple principals providers
+
+It is possible to configure multiple principals providers at the same time. For example, you can get
+principals list from ldap and user provider: the result will be ldap groups and current username. If
+you have "principalsProviders" and "principalsType" in config file, first one will be used.
+
+### Example usage
+
+```
+principalsProviders:
+  user:  # has no options yet
+  ldap:
+    ldapAddr: localhost
+    ldapPort: 3893
+    ldapTLS: False
+    ldapTLSVerify: False
+    ldapBindUser: "cn=serviceuser,ou=svcaccts,dc=glauth,dc=com"
+    ldapBindPassword: "mysecret" 
+    ldapUserBase: "dc=glauth,dc=com"
+    ldapUserSearch: "(cn=%s)"
+    ldapGroupBase: "dc=glauth,dc=com"
+    ldapGroupSearch: "(&(objectClass=group)((member=%s)))"
+```


### PR DESCRIPTION
* Add new simple "user" provider - adds your username you used to login to principles list, that's all
* Add new configuration option: principalsProviders - now we can get principals from multiple providers. It doesn't break current deployments
* Change signHandler logic a little. If one of the providers returns 0 principals, it isn't an error. If all providers returns 0 principals, it's still error.