### PR TITLE
Add ability to chain multiple principals providers

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -26,7 +26,7 @@ type Config struct {
 	Logger *logrus.Logger
 
 	Auth   authenticator.Authenticator
-	Princs principals.Principals
+	Princs []principals.Principals
 	Signer signer.Signer
 }
 

--- a/api/signHandler.go
+++ b/api/signHandler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -11,6 +12,8 @@ import (
 	"github.com/go-chi/render"
 	"github.com/signmykeyio/signmykey/client"
 	"github.com/sirupsen/logrus"
+
+	princsPkg "github.com/signmykeyio/signmykey/builtin/principals"
 )
 
 func signHandler(w http.ResponseWriter, r *http.Request) {
@@ -42,7 +45,7 @@ func signHandler(w http.ResponseWriter, r *http.Request) {
 	logger = logger.WithField("user", id)
 	logger.Info("User authenticated")
 
-	ctx, principals, err := loadPrincipals(ctx, body)
+	ctx, principals, err := loadPrincipals(ctx, body, logger)
 	if err != nil {
 		logger.WithError(err).Error("Getting list of user principals")
 		render.Status(r, 401)
@@ -66,11 +69,18 @@ func signHandler(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, map[string]string{"certificate": cert})
 }
 
-func loadPrincipals(ctx context.Context, body []byte) (context.Context, []string, error) {
+func loadPrincipals(ctx context.Context, body []byte, logger *logrus.Entry) (context.Context, []string, error) {
 	principals := []string{}
 	for _, princsProvider := range config.Princs {
 		_, princs, err := princsProvider.Get(ctx, body)
 		if err != nil {
+			// actually, this isn't an error, next provider can return principals
+			var principalsNotFoundError *princsPkg.NotFoundError
+			if errors.As(err, &principalsNotFoundError) {
+				// let admin known that this provider didn't return principals
+				logger.Info(err.Error())
+				continue
+			}
 			return ctx, []string{}, err
 		}
 

--- a/api/signHandler_test.go
+++ b/api/signHandler_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/signmykeyio/signmykey/builtin/principals"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -63,7 +64,7 @@ func TestSignHandler(t *testing.T) {
 
 	config = Config{
 		Auth:   &authMock{},
-		Princs: &princsMock{},
+		Princs: []principals.Principals{&princsMock{}},
 		Signer: &signerMock{},
 	}
 	router := Router(log.New())

--- a/api/signHandler_test.go
+++ b/api/signHandler_test.go
@@ -49,6 +49,12 @@ func TestSignHandler(t *testing.T) {
 			"application/json",
 		},
 		{
+			"POST", "/v1/sign", 401,
+			[]byte(`{"user":"emptyallprincsuser","password":"testpassword","public_key":"goodkey"}`),
+			JSONResponse{"error": "error getting list of principals"},
+			"application/json",
+		},
+		{
 			"POST", "/v1/sign", 400,
 			[]byte(`{"user":"testuser","password":"testpassword","public_key":"badkey"}`),
 			JSONResponse{"error": "unknown server error during key signing"},
@@ -108,7 +114,7 @@ func (a authMock) Login(ctx context.Context, payload []byte) (context.Context, b
 		return ctx, false, "", fmt.Errorf("JSON unmarshaling failed: %w", err)
 	}
 
-	if login.User != "testuser" && login.User != "emptyprincsuser" {
+	if login.User != "testuser" && login.User != "emptyprincsuser" && login.User != "emptyallprincsuser" {
 		return ctx, false, "", fmt.Errorf("unknown username")
 	}
 
@@ -145,6 +151,10 @@ func (p princsMock) Get(ctx context.Context, payload []byte) (context.Context, [
 	}
 
 	if login.User == "emptyprincsuser" {
+		return ctx, []string{}, principals.NewNotFoundError("mock", "empty list of principals")
+	}
+
+	if login.User == "emptyallprincsuser" {
 		return ctx, []string{}, fmt.Errorf("empty list of principals")
 	}
 

--- a/builtin/principals/Principals.go
+++ b/builtin/principals/Principals.go
@@ -11,3 +11,18 @@ type Principals interface {
 	Init(config *viper.Viper) error
 	Get(ctx context.Context, payload []byte) (context.Context, []string, error)
 }
+
+// NotFoundError it's principals provider error when no principals are found
+type NotFoundError struct {
+	provider string
+	msg      string
+}
+
+// NewNotFoundError creates new NotFoundError error with given privder name and message
+func NewNotFoundError(provider, msg string) *NotFoundError {
+	return &NotFoundError{provider: provider, msg: msg}
+}
+
+func (e *NotFoundError) Error() string {
+	return e.provider + ": " + e.msg
+}

--- a/builtin/principals/ldap/Principals.go
+++ b/builtin/principals/ldap/Principals.go
@@ -135,7 +135,7 @@ func (p Principals) Get(ctx context.Context, payload []byte) (context.Context, [
 	}
 
 	if len(gsr.Entries) == 0 {
-		return ctx, []string{}, princsPkg.NewNotFoundError("ldap", "No group found for user "+ldapPrinc.User)
+		return ctx, []string{}, princsPkg.NewNotFoundError("ldap", "No group found")
 	}
 
 	var principals []string

--- a/builtin/principals/ldap/Principals.go
+++ b/builtin/principals/ldap/Principals.go
@@ -14,6 +14,8 @@ import (
 	"github.com/signmykeyio/signmykey/builtin/principals/common"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+
+	princsPkg "github.com/signmykeyio/signmykey/builtin/principals"
 )
 
 // Principals struct represents LDAP options for getting principals list from LDAP.
@@ -133,7 +135,7 @@ func (p Principals) Get(ctx context.Context, payload []byte) (context.Context, [
 	}
 
 	if len(gsr.Entries) == 0 {
-		return ctx, []string{}, errors.New("no group found for this user")
+		return ctx, []string{}, princsPkg.NewNotFoundError("ldap", "No group found for user "+ldapPrinc.User)
 	}
 
 	var principals []string

--- a/builtin/principals/local/Principals.go
+++ b/builtin/principals/local/Principals.go
@@ -9,6 +9,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+
+	princsPkg "github.com/signmykeyio/signmykey/builtin/principals"
 )
 
 // Principals struct represents map of principals by user.
@@ -42,7 +44,7 @@ func (p Principals) Get(ctx context.Context, payload []byte) (context.Context, [
 	}
 
 	if !p.UserMap.IsSet(local.User) {
-		return ctx, []string{}, fmt.Errorf("No principals found for %s", local.User)
+		return ctx, []string{}, princsPkg.NewNotFoundError("local", "No principals found for "+local.User)
 	}
 
 	principals := []string{}
@@ -54,7 +56,7 @@ func (p Principals) Get(ctx context.Context, payload []byte) (context.Context, [
 	}
 
 	if len(principals) == 0 {
-		return ctx, principals, fmt.Errorf("No more principals after trim for %s", local.User)
+		return ctx, principals, princsPkg.NewNotFoundError("local", "No more principals after trim for "+local.User)
 	}
 
 	return ctx, principals, nil

--- a/builtin/principals/local/Principals.go
+++ b/builtin/principals/local/Principals.go
@@ -44,7 +44,7 @@ func (p Principals) Get(ctx context.Context, payload []byte) (context.Context, [
 	}
 
 	if !p.UserMap.IsSet(local.User) {
-		return ctx, []string{}, princsPkg.NewNotFoundError("local", "No principals found for "+local.User)
+		return ctx, []string{}, princsPkg.NewNotFoundError("local", "No principals found")
 	}
 
 	principals := []string{}
@@ -56,7 +56,7 @@ func (p Principals) Get(ctx context.Context, payload []byte) (context.Context, [
 	}
 
 	if len(principals) == 0 {
-		return ctx, principals, princsPkg.NewNotFoundError("local", "No more principals after trim for "+local.User)
+		return ctx, principals, princsPkg.NewNotFoundError("local", "No more principals after trim")
 	}
 
 	return ctx, principals, nil

--- a/cmd/server_dev.go
+++ b/cmd/server_dev.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/signmykeyio/signmykey/api"
 	localAuth "github.com/signmykeyio/signmykey/builtin/authenticator/local"
+	"github.com/signmykeyio/signmykey/builtin/principals"
 	localPrinc "github.com/signmykeyio/signmykey/builtin/principals/local"
 	localSign "github.com/signmykeyio/signmykey/builtin/signer/local"
 	"github.com/sirupsen/logrus"
@@ -87,7 +88,7 @@ users:
 
 		config := api.Config{
 			Auth:   auth,
-			Princs: princs,
+			Princs: []principals.Principals{princs},
 			Signer: signer,
 
 			Logger: logger,

--- a/docs/content/backends/principals/index.md
+++ b/docs/content/backends/principals/index.md
@@ -80,3 +80,33 @@ this provider.
 ```
 principalsType: user
 ```
+
+## Multiple principals providers
+
+It is possible to configure multiple principals providers at the same time. For example, you can "chain"
+user, ldap and local providers: the resulted principals list will be your user name, ldap groups and 
+local principals.
+
+If "principalsProviders" and "principalsType" are both configured, first one will be used.
+
+### Example usage
+
+```
+principalsProviders:
+  user:  # has no options yet
+  ldap:
+    ldapAddr: localhost
+    ldapPort: 3893
+    ldapTLS: False
+    ldapTLSVerify: False
+    ldapBindUser: "cn=serviceuser,ou=svcaccts,dc=glauth,dc=com"
+    ldapBindPassword: "mysecret"
+    ldapUserBase: "dc=glauth,dc=com"
+    ldapUserSearch: "(cn=%s)"
+    ldapGroupBase: "dc=glauth,dc=com"
+    ldapGroupSearch: "(&(objectClass=group)((member=%s)))"
+  local:
+    users:
+      foouser: fooprincpal,anotherprincipal,thirdprincipal
+      baruser: anotherprincipal
+```


### PR DESCRIPTION
Hello. This is next PR that:

* adds ability to chain multiple principals providers
* adds new configuration option: principalsProviders. It doesn't break current deployments, but if principalsProviders and principalsType are both configured, first one will be used
* changes signHandler logic a little. If each of the principals providers returns 0 principals, it isn't an error. If all providers return 0 principals, it's still error.

PS. I know, this PR is still a little big, but it's all about one feature, I don't know how to break it in smaller parts.