### PR TITLE
Make password request more clear

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,7 +56,7 @@ var rootCmd = &cobra.Command{
 
 		password := viper.GetString("password")
 		if password == "" {
-			fmt.Printf("Password (will be hidden): ")
+			fmt.Printf("Enter signmykey password (will be hidden): ")
 			passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
 			if err != nil {
 				return err


### PR DESCRIPTION
signmykey uses short-lived certificates. I made useful alias `alias ssh='signmykey -e; ssh'` to improve my workflow: when I ssh to a server, signmykey checks if my certificate is expired or not. If expired - sighmykey asks for a password.

In that case, password prompt message is not very clear. I suggest to mention signmykey name explicitly:

```bash
$ ssh server
Enter signmykey password (will be hidden): 
```