### PR TITLE
Multiple keys

### DIFF
--- a/api/signHandler.go
+++ b/api/signHandler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -27,7 +27,7 @@ func signHandler(w http.ResponseWriter, r *http.Request) {
 		"req_id":  reqID,
 	})
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		logger.WithError(err).Error("Reading signing request body")
 		render.Status(r, 400)

--- a/api/signHandler.go
+++ b/api/signHandler.go
@@ -63,7 +63,7 @@ func signHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, before, _ := client.CertInfo(cert)
+	_, before, _, _ := client.CertInfo(cert)
 	logger.WithField("expire", time.Unix(int64(before), 0)).Info("SSH certificate generated")
 
 	render.JSON(w, r, map[string]string{"certificate": cert})

--- a/builtin/authenticator/oidcropc/Authenticator.go
+++ b/builtin/authenticator/oidcropc/Authenticator.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -100,7 +100,7 @@ func (a *Authenticator) Login(ctx context.Context, payload []byte) (resultCtx co
 	}
 	defer resToken.Body.Close()
 
-	bodyToken, err := ioutil.ReadAll(resToken.Body)
+	bodyToken, err := io.ReadAll(resToken.Body)
 	if err != nil {
 		return ctx, false, "", errors.New("can't read body")
 	}

--- a/builtin/principals/oidcropc/Principals.go
+++ b/builtin/principals/oidcropc/Principals.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -89,7 +89,7 @@ func (p Principals) Get(ctx context.Context, payload []byte) (context.Context, [
 
 	defer resInfo.Body.Close()
 
-	bodyInfo, err := ioutil.ReadAll(resInfo.Body)
+	bodyInfo, err := io.ReadAll(resInfo.Body)
 	if err != nil {
 		return ctx, []string{}, err
 	}

--- a/builtin/signer/local/Signer.go
+++ b/builtin/signer/local/Signer.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/signmykeyio/signmykey/builtin/signer"
@@ -44,7 +44,7 @@ func (s *Signer) Init(config *viper.Viper) error {
 	}
 
 	// Read and parse CA private key
-	key, err := ioutil.ReadFile(config.GetString("caKey"))
+	key, err := os.ReadFile(config.GetString("caKey"))
 	if err != nil {
 		return fmt.Errorf("error reading CA private key file %s: %w", config.GetString("caKey"), err)
 	}
@@ -54,7 +54,7 @@ func (s *Signer) Init(config *viper.Viper) error {
 	}
 
 	// Read and parse CA public key
-	pubKey, err := ioutil.ReadFile(config.GetString("caCert"))
+	pubKey, err := os.ReadFile(config.GetString("caCert"))
 	if err != nil {
 		return fmt.Errorf("error reading CA public key file %s: %w", config.GetString("caCert"), err)
 	}

--- a/builtin/signer/vault/Signer.go
+++ b/builtin/signer/vault/Signer.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -96,7 +96,7 @@ func (v Signer) ReadCA(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("unknown error from Vault with status code %d", resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("error reading response body: %w", err)
 	}
@@ -175,7 +175,7 @@ func (v Signer) Sign(ctx context.Context, payload []byte, id string, principals 
 }
 
 func extractSignedKey(resp *http.Response) (string, error) {
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("error reading response body: %w", err)
 	}
@@ -229,7 +229,7 @@ func (v Signer) getToken(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("unknown error during authentication with status code %d", resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/client/files.go
+++ b/client/files.go
@@ -139,7 +139,7 @@ Please generate at least one with command like this :
 
 		// keys list is not explicitly set, suggest generating ed25519 as default
 		if reflect.DeepEqual(keys, DefaultSSHKeys) {
-			errStr += fmt.Sprint("\tssh-keygen -f ~/.ssh/id_ed25519 -t ed25519\n")
+			errStr += "\tssh-keygen -f ~/.ssh/id_ed25519 -t ed25519\n"
 		} else {
 			for _, key := range keys {
 				suggestedSSHKey := strings.Replace(key, ".pub", "", 1)

--- a/client/files.go
+++ b/client/files.go
@@ -153,14 +153,14 @@ Please generate at least one with command like this :
 
 func chooseSSHKeyType(key string) string {
 	switch {
-	case strings.Contains(key, "dsa"):
-		return "dsa"
 	case strings.Contains(key, "ecdsa_sk"):
 		return "ecdsa-sk"
+	case strings.Contains(key, "ed25519_sk"):
+		return "ed25519-sk"
 	case strings.Contains(key, "ecdsa"):
 		return "ecdsa"
-	case strings.Contains(key, "ed25519_sk"):
-		return "ecdsa-sk"
+	case strings.Contains(key, "dsa"):
+		return "dsa"
 	case strings.Contains(key, "rsa"):
 		return "rsa"
 	default:

--- a/client/files.go
+++ b/client/files.go
@@ -162,7 +162,7 @@ func chooseSSHKeyType(key string) string {
 	case strings.Contains(key, "dsa"):
 		return "dsa"
 	case strings.Contains(key, "rsa"):
-		return "rsa"
+		return "rsa-sha2-512"
 	default:
 		return "ed25519"
 	}

--- a/client/files.go
+++ b/client/files.go
@@ -142,7 +142,12 @@ Please generate at least one with command like this :
 		} else {
 			for _, key := range keys {
 				suggestedSSHKey := strings.Replace(key, ".pub", "", 1)
-				errStr += fmt.Sprintf("\tssh-keygen -f %s -t %s\n", suggestedSSHKey, chooseSSHKeyType(suggestedSSHKey))
+				suggestedSSHType, isDeprecated := chooseSSHKeyType(suggestedSSHKey)
+				if isDeprecated {
+					errStr += fmt.Sprintf("\tssh-keygen -f %s -t %s [deprecated, consider using ed25519 instead]\n", suggestedSSHKey, suggestedSSHType)
+				} else {
+					errStr += fmt.Sprintf("\tssh-keygen -f %s -t %s\n", suggestedSSHKey, suggestedSSHType)
+				}
 			}
 		}
 
@@ -151,19 +156,20 @@ Please generate at least one with command like this :
 	return found, nil
 }
 
-func chooseSSHKeyType(key string) string {
+// chooseSSHKeyType returns ssh type and deprecated flag based on ssh public key file name
+func chooseSSHKeyType(key string) (string, bool) {
 	switch {
 	case strings.Contains(key, "ecdsa_sk"):
-		return "ecdsa-sk"
+		return "ecdsa-sk", false
 	case strings.Contains(key, "ed25519_sk"):
-		return "ed25519-sk"
+		return "ed25519-sk", false
 	case strings.Contains(key, "ecdsa"):
-		return "ecdsa"
+		return "ecdsa", false
 	case strings.Contains(key, "dsa"):
-		return "dsa"
+		return "dsa", true
 	case strings.Contains(key, "rsa"):
-		return "rsa-sha2-512"
+		return "rsa-sha2-512", false
 	default:
-		return "ed25519"
+		return "ed25519", false
 	}
 }

--- a/client/files.go
+++ b/client/files.go
@@ -168,7 +168,7 @@ func chooseSSHKeyType(key string) (string, bool) {
 	case strings.Contains(key, "dsa"):
 		return "dsa", true
 	case strings.Contains(key, "rsa"):
-		return "rsa-sha2-512", false
+		return "rsa", false
 	default:
 		return "ed25519", false
 	}

--- a/client/files.go
+++ b/client/files.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -30,7 +29,7 @@ func GetUserPubKey(key string) (string, error) {
 		return "", err
 	}
 
-	pubKey, err := ioutil.ReadFile(pubKeyPath) // nolint: gosec
+	pubKey, err := os.ReadFile(pubKeyPath) // nolint: gosec
 	if err != nil {
 		return "", err
 	}
@@ -63,7 +62,7 @@ func CertStillValid(path string) bool {
 		return false
 	}
 
-	cert, err := ioutil.ReadFile(fullPath) // nolint: gosec
+	cert, err := os.ReadFile(fullPath) // nolint: gosec
 	if err != nil {
 		return false
 	}

--- a/client/files.go
+++ b/client/files.go
@@ -13,7 +13,7 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 )
 
-// based on `man ssh` -i identity_file default values
+// DefaultSSHKeys is based on `man ssh` -i identity_file default values
 var DefaultSSHKeys = []string{
 	"~/.ssh/id_dsa.pub",
 	"~/.ssh/id_ecdsa.pub",

--- a/client/files.go
+++ b/client/files.go
@@ -78,15 +78,15 @@ func CertStillValid(path string) bool {
 }
 
 // CertInfo extract principals and expiration from SSH certificate
-func CertInfo(cert string) (principals []string, before uint64, err error) {
+func CertInfo(cert string) (principals []string, before uint64, algo string, err error) {
+	algo = strings.Split(cert, " ")[0]
 	parsedKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(cert))
 	if err != nil {
-		return principals, before, err
+		return principals, before, algo, err
 	}
-
 	parsedCert := parsedKey.(*ssh.Certificate)
 
-	return parsedCert.ValidPrincipals, parsedCert.ValidBefore, nil
+	return parsedCert.ValidPrincipals, parsedCert.ValidBefore, algo, nil
 }
 
 // WriteUserSignedKey writes user certificate on disk.
@@ -171,5 +171,17 @@ func chooseSSHKeyType(key string) (string, bool) {
 		return "rsa", false
 	default:
 		return "ed25519", false
+	}
+}
+
+// CertAlgoIsDeprecated returns true if certificate algorithm is deprecated by openssh
+func CertAlgoIsDeprecated(s string) bool {
+	switch {
+	case s == ssh.CertAlgoRSAv01:
+		return true
+	case s == ssh.CertAlgoDSAv01:
+		return true
+	default:
+		return false
 	}
 }

--- a/client/files.go
+++ b/client/files.go
@@ -119,20 +119,36 @@ func FindUserPubKeys(keys []string) ([]string, error) {
 		}
 	}
 
-	suggestedSSHKey := "~/.ssh/id_ed25519"
-	// we set only 1 key in smk.yml, suggest to generate it if it doesn't exist
-	if len(keys) == 1 {
-		suggestedSSHKey = strings.Replace(keys[0], ".pub", "", 1)
-	}
-
-	// TODO: add type -t ed25519
 	if len(found) == 0 {
-		return nil, fmt.Errorf(`user SSH keys at %s doesn't exist.
+		suggestedSSHKey := "~/.ssh/id_ed25519"
+		// only 1 key set in smk.yml, suggest to generate it if it doesn't exist
+		if len(keys) == 1 {
+			suggestedSSHKey = strings.Replace(keys[0], ".pub", "", 1)
+		}
+
+		return nil, fmt.Errorf(`user SSH key(s) at %s doesn't exist.
 
 Please generate one with this command :
 
-	ssh-keygen -f %s`,
-			strings.Join(keys, ", "), suggestedSSHKey)
+	ssh-keygen -f %s -t %s`,
+			strings.Join(keys, ", "), suggestedSSHKey, chooseSSHKeyType(suggestedSSHKey))
 	}
 	return found, nil
+}
+
+func chooseSSHKeyType(key string) string {
+	switch {
+	case strings.Contains(key, "dsa"):
+		return "dsa"
+	case strings.Contains(key, "ecdsa_sk"):
+		return "ecdsa-sk"
+	case strings.Contains(key, "ecdsa"):
+		return "ecdsa"
+	case strings.Contains(key, "ed25519_sk"):
+		return "ecdsa-sk"
+	case strings.Contains(key, "rsa"):
+		return "rsa"
+	default:
+		return "ed25519"
+	}
 }

--- a/client/files_test.go
+++ b/client/files_test.go
@@ -27,3 +27,22 @@ func TestChooseSSHKeyType(t *testing.T) {
 		assert.Equal(t, c.keyDeprecated, isDeprecated)
 	}
 }
+
+
+func TestCertAlgoIsDeprecated(t *testing.T) {
+	cases := []struct {
+		algo string
+		isDeprecated bool
+	}{
+		{"ssh-rsa-cert-v01@openssh.com", true},
+		{"ssh-dss-cert-v01@openssh.com", true},
+		{"ssh-ed25519-cert-v01@openssh.com", false},
+		{"rsa-sha2-256-cert-v01@openssh.com", false},
+		{"rsa-sha2-512-cert-v01@openssh.com", false},
+	}
+
+	for _, c := range cases {
+		isDeprecated := CertAlgoIsDeprecated(c.algo)
+		assert.Equal(t, c.isDeprecated, isDeprecated)
+	}
+}

--- a/client/files_test.go
+++ b/client/files_test.go
@@ -16,7 +16,7 @@ func TestChooseSSHKeyType(t *testing.T) {
 		{"~/.ssh/id_ecdsa_sk.pub", "ecdsa-sk"},
 		{"~/.ssh/id_ed25519.pub", "ed25519"},
 		{"~/.ssh/id_ed25519_sk.pub", "ed25519-sk"},
-		{"~/.ssh/id_rsa.pub", "rsa"},
+		{"~/.ssh/id_rsa.pub", "rsa-sha2-512"},
 		{"~/.ssh/test_default_type.pub", "ed25519"},
 	}
 

--- a/client/files_test.go
+++ b/client/files_test.go
@@ -17,7 +17,7 @@ func TestChooseSSHKeyType(t *testing.T) {
 		{"~/.ssh/id_ecdsa_sk.pub", "ecdsa-sk", false},
 		{"~/.ssh/id_ed25519.pub", "ed25519", false},
 		{"~/.ssh/id_ed25519_sk.pub", "ed25519-sk", false},
-		{"~/.ssh/id_rsa.pub", "rsa-sha2-512", false},
+		{"~/.ssh/id_rsa.pub", "rsa", false},
 		{"~/.ssh/test_default_type.pub", "ed25519", false},
 	}
 

--- a/client/files_test.go
+++ b/client/files_test.go
@@ -8,20 +8,22 @@ import (
 
 func TestChooseSSHKeyType(t *testing.T) {
 	cases := []struct {
-		keyName string
-		keyType string
+		keyName       string
+		keyType       string
+		keyDeprecated bool
 	}{
-		{"~/.ssh/id_dsa.pub", "dsa"},
-		{"~/.ssh/id_ecdsa.pub", "ecdsa"},
-		{"~/.ssh/id_ecdsa_sk.pub", "ecdsa-sk"},
-		{"~/.ssh/id_ed25519.pub", "ed25519"},
-		{"~/.ssh/id_ed25519_sk.pub", "ed25519-sk"},
-		{"~/.ssh/id_rsa.pub", "rsa-sha2-512"},
-		{"~/.ssh/test_default_type.pub", "ed25519"},
+		{"~/.ssh/id_dsa.pub", "dsa", true},
+		{"~/.ssh/id_ecdsa.pub", "ecdsa", false},
+		{"~/.ssh/id_ecdsa_sk.pub", "ecdsa-sk", false},
+		{"~/.ssh/id_ed25519.pub", "ed25519", false},
+		{"~/.ssh/id_ed25519_sk.pub", "ed25519-sk", false},
+		{"~/.ssh/id_rsa.pub", "rsa-sha2-512", false},
+		{"~/.ssh/test_default_type.pub", "ed25519", false},
 	}
 
 	for _, c := range cases {
-		keyType := chooseSSHKeyType(c.keyName)
+		keyType, isDeprecated := chooseSSHKeyType(c.keyName)
 		assert.Equal(t, c.keyType, keyType)
+		assert.Equal(t, c.keyDeprecated, isDeprecated)
 	}
 }

--- a/client/files_test.go
+++ b/client/files_test.go
@@ -1,0 +1,27 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChooseSSHKeyType(t *testing.T) {
+	cases := []struct {
+		keyName string
+		keyType string
+	}{
+		{"~/.ssh/id_dsa.pub", "dsa"},
+		{"~/.ssh/id_ecdsa.pub", "ecdsa"},
+		{"~/.ssh/id_ecdsa_sk.pub", "ecdsa-sk"},
+		{"~/.ssh/id_ed25519.pub", "ed25519"},
+		{"~/.ssh/id_ed25519_sk.pub", "ed25519-sk"},
+		{"~/.ssh/id_rsa.pub", "rsa"},
+		{"~/.ssh/test_default_type.pub", "ed25519"},
+	}
+
+	for _, c := range cases {
+		keyType := chooseSSHKeyType(c.keyName)
+		assert.Equal(t, c.keyType, keyType)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,24 +83,24 @@ var rootCmd = &cobra.Command{
 		for _, pubKeyFile := range pubKeysFiles {
 			pubKey, err := client.GetUserPubKey(pubKeyFile)
 			if err != nil {
-				return err
+				return fmt.Errorf("%v, public key: %v", err, pubKeyFile)
 			}
 
 			signedKey, err := client.Sign(smkAddr, username, password, pubKey)
 			if err != nil {
-				return err
+				return fmt.Errorf("%v, public key: %v", err, pubKeyFile)
 			}
 
 			err = client.WriteUserSignedKey(signedKey, pubKeyFile)
 			if err != nil {
-				return err
+				return fmt.Errorf("%v, public key: %v", err, pubKeyFile)
 			}
 
 			color.Green("\nYour SSH Key %s is successfully signed !", pubKeyFile)
 
 			principals, before, err := client.CertInfo(signedKey)
 			if err != nil {
-				return err
+				return fmt.Errorf("%v, public key: %v", err, pubKeyFile)
 			}
 			color.HiBlack("\n  - Valid until: %s", time.Unix(int64(before), 0))
 			color.HiBlack("  - Principals: %s", strings.Join(principals, ","))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,16 +19,6 @@ import (
 
 var clientCfgFile string
 
-// based on `man ssh` -i identity_file default values
-var defaultSSHKeys = []string{
-	"~/.ssh/id_dsa.pub",
-	"~/.ssh/id_ecdsa.pub",
-	"~/.ssh/id_ecdsa_sk.pub",
-	"~/.ssh/id_ed25519.pub",
-	"~/.ssh/id_ed25519_sk.pub",
-	"~/.ssh/id_rsa.pub",
-}
-
 var rootCmd = &cobra.Command{
 	Use:           "signmykey",
 	Short:         "A client-server to sign ssh keys",
@@ -152,7 +142,7 @@ func init() {
 		os.Exit(1)
 	}
 
-	rootCmd.Flags().StringSliceP("key", "k", defaultSSHKeys, "Path of public key to sign")
+	rootCmd.Flags().StringSliceP("key", "k", client.DefaultSSHKeys, "Path of public key to sign")
 	if err := viper.BindPFlag("key", rootCmd.Flags().Lookup("key")); err != nil {
 		color.Red(fmt.Sprintf("%s", err))
 		os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,8 +35,7 @@ var rootCmd = &cobra.Command{
 			return errors.New("SMK Server address must end with a slash")
 		}
 
-		_, err := client.FindUserPubKeys(viper.GetStringSlice("key"))
-		return err
+		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		pubKeysFiles := []string{}


### PR DESCRIPTION
Hello, this is PR for https://github.com/signmykeyio/signmykey/issues/133

I tested it for these cases:

* if key is not set, search for keys in default paths (ask to generate ssh ed25519 key if not found)
* if 1 key is set (as string in yaml, or as single `-k` argument), use this key (ask to generate if not found)
* if >1 keys are set (as list of strings in yaml or as multiple `-k` argument), search for them and use only existent keys. If at least 1 key found, use it. If no keys found, ask for generate at least 1 from given list