### PR TITLE
Otp extension for local authenticator

### DIFF
--- a/api/login.go
+++ b/api/login.go
@@ -7,6 +7,7 @@ type Login struct {
 	User     string `json:"user" binding:"required"`
 	Password string `json:"password" binding:"required"`
 	PubKey   string `json:"public_key" binding:"required"`
+	Otp	string `json:"otp"`
 }
 
 // Validate fields of login struct

--- a/builtin/authenticator/local/Authenticator.go
+++ b/builtin/authenticator/local/Authenticator.go
@@ -5,10 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"golang.org/x/crypto/bcrypt"
+	"github.com/signmykeyio/signmykey/util"
 )
 
 // Authenticator struct represents local Authenticator options
@@ -19,6 +22,7 @@ type Authenticator struct {
 type localLogin struct {
 	User     string `json:"user" binding:"required"`
 	Password string `json:"password" binding:"required"`
+	Otp string `json:"otp"`
 }
 
 // Init method is used to ingest config of Authenticator
@@ -55,9 +59,27 @@ func (a Authenticator) Login(ctx context.Context, payload []byte) (resultCtx con
 		return ctx, false, "", errors.New("user not found")
 	}
 
-	err = bcrypt.CompareHashAndPassword([]byte(hashedPass), []byte(login.Password))
+	passAndOtp := strings.Split(hashedPass, ",")
+	if len(passAndOtp[1]) !=0 && len(login.Otp) == 0  {
+		return ctx, false, "", errors.New("otp required but not provided")
+	}
+
+	err = bcrypt.CompareHashAndPassword([]byte(passAndOtp[0]), []byte(login.Password))
 	if err != nil {
 		return ctx, false, "", errors.New("bad password")
+	}
+
+	if len(passAndOtp[1]) !=0 {
+		seed := util.DecryptSeed(passAndOtp[1], []byte(login.Password))
+		timeval := time.Now().Unix() / 30
+		generated := util.GenerateOTPCode(seed, timeval)
+		if login.Otp != generated {
+			// try again as industry standard is a 30 sec tolerance window
+			timeval = timeval - 30
+			if login.Otp != util.GenerateOTPCode(seed, timeval) {
+				return ctx, false, "", errors.New("otp does not match")
+			}
+		}
 	}
 
 	return ctx, true, fmt.Sprintf("local-%s", login.User), nil

--- a/client/sign.go
+++ b/client/sign.go
@@ -10,6 +10,7 @@ type signLDAPRequest struct {
 	User      string `json:"user"`
 	Password  string `json:"password"`
 	PublicKey string `json:"public_key"`
+	Otp	string `json:"otp"`
 }
 
 type signLDAPResponse struct {
@@ -21,12 +22,13 @@ type signLDAPError struct {
 }
 
 // Sign is used to sign an SSH key with user/password combination.
-func Sign(addr, user, password, pubKey string) (certificate string, err error) {
+func Sign(addr, user, password, pubKey, otp string) (certificate string, err error) {
 
 	body := &signLDAPRequest{
 		User:      user,
 		Password:  password,
 		PublicKey: pubKey,
+		Otp: 		otp,
 	}
 
 	signResponse := &signLDAPResponse{}

--- a/cmd/hash.go
+++ b/cmd/hash.go
@@ -7,6 +7,8 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/term"
+	"github.com/mdp/qrterminal/v3"
+	"github.com/signmykeyio/signmykey/util"
 )
 
 var hashCmd = &cobra.Command{
@@ -25,7 +27,24 @@ var hashCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Printf("\nHashed password: %s\n", string(hash))
+               fmt.Printf("\nDo you want to use One Time Codes e.g. Google authenticator? (Y/N) ")
+               var useOtp string
+               fmt.Scanln(&useOtp)
+
+               if useOtp == "Y"  || useOtp == "y" {
+                       seed := util.GenerateSeed()
+                       encryptedSeed := util.EncryptSeed(seed, password)
+                       str := util.ProvisionURI(seed)
+
+                       fmt.Printf("\nScan this with your OTP application\n")
+                       qrterminal.GenerateHalfBlock(str, qrterminal.L, os.Stdout)
+                       fmt.Printf("\n...or create a new OTP secret manually if you cannot scan QR codes")
+		       fmt.Printf("\nOTP Secret: %s\n", seed)
+                       fmt.Printf("\nHashed password: %s\n", string(hash) + "," + encryptedSeed)
+
+               } else {
+                       fmt.Printf("\nHashed password: %s\n", string(hash))
+               }
 
 		return nil
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,6 +77,8 @@ var rootCmd = &cobra.Command{
 			smkAddr = smkAddr + "/"
 		}
 
+		otp := viper.GetString("otp")
+
 		var deprecatedKeys, buggyKeys, totalKeys int
 		for _, pubKeyFile := range pubKeysFiles {
 			pubKey, err := client.GetUserPubKey(pubKeyFile)
@@ -84,7 +86,7 @@ var rootCmd = &cobra.Command{
 				return fmt.Errorf("%v, public key: %v", err, pubKeyFile)
 			}
 
-			signedKey, err := client.Sign(smkAddr, username, password, pubKey)
+			signedKey, err := client.Sign(smkAddr, username, password, pubKey, otp)
 			if err != nil {
 				return fmt.Errorf("%v, public key: %v", err, pubKeyFile)
 			}
@@ -167,6 +169,12 @@ func init() {
 
 	rootCmd.Flags().BoolP("expired", "e", false, "Sign only if existing key already expired")
 	if err := viper.BindPFlag("expired", rootCmd.Flags().Lookup("expired")); err != nil {
+		color.Red(fmt.Sprintf("%s", err))
+		os.Exit(1)
+	}
+
+	rootCmd.Flags().StringP("otp", "o", "", "One time password")
+	if err := viper.BindPFlag("otp", rootCmd.Flags().Lookup("otp")); err != nil {
 		color.Red(fmt.Sprintf("%s", err))
 		os.Exit(1)
 	}

--- a/docs/content/backends/authenticator/index.md
+++ b/docs/content/backends/authenticator/index.md
@@ -12,11 +12,15 @@ authenticatorOpts:
   users:
     foouser: $2a$10$zsvMZ7nEYo4jJJxgb5FpH.izPH37LsuLBXPbuKH4MPF4sihFSG6bW
     baruser: $2a$10$srGqC9g46xaRXbueLk5kDuSuDM6h2EpC.MTRiVaij6s/jcsKQ6LHu
+    otpuser: $2a$10$/6T2iN8I7UTUTDuezVH41eDlSIeNr32wi9PtDfNF3Zxes3RO0LK/a,VHOUR7WH7N6ZXI5VEKZFZ4ESB4ZEYPGNUDAT6LKGNHLWUXMTEYKA====
 ```
 
 ### Options
 
   * **users** - Map of users and bcrypt hashed passwords (you can hash passwords via "signmykey hash" command) (required)
+
+Optionally, users may wish to utilize OTP in which case the "signmykey hash" command generates a longer string which contains the 
+hashed password and the OTP seed encrypted with the user's password. 
 
 ## LDAP
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-chi/render v1.0.2
 	github.com/go-ldap/ldap/v3 v3.4.4
+	github.com/mdp/qrterminal/v3 v3.0.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
@@ -41,6 +42,7 @@ require (
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	rsc.io/qr v0.2.0 // indirect
 )
 
 go 1.18

--- a/util/otp.go
+++ b/util/otp.go
@@ -1,0 +1,115 @@
+package util
+
+import (
+	"fmt"
+	"net/url"
+	"encoding/base32"
+	"encoding/binary"
+	"crypto/rand"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/sha1"
+	"io"
+	"bytes"
+	"math"
+)
+
+func GenerateSeed() string {
+	data := make([]byte,10)
+	_, err := rand.Read(data)
+	if err != nil {
+		return "error"
+	}
+	seed := base32.StdEncoding.EncodeToString(data)
+
+	return seed
+}
+
+
+func EncryptSeed(seed string, password []byte) string {
+	// Make a key that is 16 byte long, using as many repetitions
+	// of the password as needed
+	key := make([]byte, 16)
+        rep :=  1 + 16 / len(password)
+        key = bytes.Repeat(password, rep)
+
+        plaintext := []byte(seed)
+
+        //Create a new Cipher Block from the key
+	block, err := aes.NewCipher(key[:16])
+        if err != nil {
+                panic(err)
+        }
+
+        ciphertext := make([]byte, aes.BlockSize+len(plaintext))
+        iv := ciphertext[:aes.BlockSize]
+        if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+                panic(err)
+        }
+
+        stream := cipher.NewCFBEncrypter(block, iv)
+        stream.XORKeyStream(ciphertext[aes.BlockSize:], plaintext)
+
+        return base32.StdEncoding.EncodeToString(ciphertext)
+}
+
+func DecryptSeed(encryptedSeed string, password []byte) string {
+	// Make a key that is 16 byte long, using as many repetitions
+	// of the password as needed
+	key := make([]byte, 16)
+        rep :=  1 + 16 / len(password)
+        key = bytes.Repeat(password, rep)
+
+        ciphertext, _ := base32.StdEncoding.DecodeString(encryptedSeed)
+	
+	block, err := aes.NewCipher(key[:16])
+        if err != nil {
+                panic(err)
+        }
+
+        if len(ciphertext) < aes.BlockSize {
+                panic("ciphertext too short")
+        }
+        iv := ciphertext[:aes.BlockSize]
+        ciphertext = ciphertext[aes.BlockSize:]
+
+        stream := cipher.NewCFBDecrypter(block, iv)
+        stream.XORKeyStream(ciphertext, ciphertext)
+
+        return fmt.Sprintf("%s", ciphertext)
+}
+
+func ProvisionURI(secret string) string {
+        auth := "totp/"
+        label := "SignMyKey"
+        q := make(url.Values)
+        q.Add("secret", secret)
+        q.Add("issuer", "SignMyKey")
+
+        return "otpauth://" + auth + label + "?" + q.Encode()
+}
+
+func GenerateOTPCode(seed string, timeval int64) (string) { 
+
+	secretBytes, err := base32.StdEncoding.DecodeString(seed)
+	if err != nil {
+                panic(err)
+	}
+
+	buf := make([]byte, 8)
+	hash := hmac.New(sha1.New, secretBytes)
+	binary.BigEndian.PutUint64(buf, uint64(timeval))
+	hash.Write(buf)
+	sum := hash.Sum(nil)
+
+	offset := sum[len(sum)-1] & 0xf
+	value := int64(((int(sum[offset]) & 0x7f) << 24) |
+		((int(sum[offset+1] & 0xff)) << 16) |
+		((int(sum[offset+2] & 0xff)) << 8) |
+		(int(sum[offset+3]) & 0xff))
+
+	mod := int32(value % int64(math.Pow10(6)))
+
+	return fmt.Sprintf(fmt.Sprintf("%%0%dd", 6), mod) 
+}


### PR DESCRIPTION
The implementation extends the local authenticator with the option to use (T)OTP codes. 
It should be backwards compatible and both otp-enabled and non-otp-enabled accounts are supported at the same time. 

There are no additional security threats with this implementation. 
Nevertheless, if someone has access to the server.yml file, one can remove the OTP requirement. 
But then, of course, they can change the password altogether beyond just removing the OTP so this is an inherent existing threat and not a new one.

Parts of the code derived from https://github.com/pquerna/otp/ (Apache License 2.0)  