### PR TITLE
Fix missing OIDC scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ signmykey
 main
 docs/public
 bin/
+.vscode/

--- a/builtin/authenticator/oidcropc/Authenticator.go
+++ b/builtin/authenticator/oidcropc/Authenticator.go
@@ -83,6 +83,7 @@ func (a *Authenticator) Login(ctx context.Context, payload []byte) (resultCtx co
 	v.Add("password", login.Password)
 	v.Add("client_id", a.OIDCClientID)
 	v.Add("client_secret", a.OIDCClientSecret)
+	v.Add("scope", "openid")
 
 	oidcPayload := strings.NewReader(v.Encode())
 


### PR DESCRIPTION
Since the implementation of Keycloak PR https://github.com/keycloak/keycloak/pull/14237, the OIDC userinfo endpoint requires the "openid" scope in the token for access authorization.