### PR TITLE
fix: add staticcheck nolint comments for deprecated DSA usage

### DIFF
--- a/client/files.go
+++ b/client/files.go
@@ -178,7 +178,7 @@ func chooseSSHKeyType(key string) (string, bool) {
 // CertKeyTypeIsDeprecated returns true if certificate key type is deprecated by openssh
 func CertKeyTypeIsDeprecated(s string) bool {
 	switch {
-	case s == ssh.CertAlgoDSAv01:
+	case s == ssh.CertAlgoDSAv01: //nolint:staticcheck
 		return true
 	default:
 		return false

--- a/client/files_test.go
+++ b/client/files_test.go
@@ -36,7 +36,7 @@ func TestCertKeyTypeIsBuggy(t *testing.T) {
 		isBuggy bool
 	}{
 		{ssh.KeyAlgoRSA, true},
-		{ssh.KeyAlgoDSA, false},
+		{ssh.KeyAlgoDSA, false}, //nolint:staticcheck
 		{ssh.KeyAlgoED25519, false},
 		{ssh.KeyAlgoECDSA256, false},
 	}


### PR DESCRIPTION
Adds staticcheck nolint comments to suppress warnings for deprecated DSA usage in both client/files.go and client/files_test.go